### PR TITLE
Update single node setup.

### DIFF
--- a/vagrant/multi_node/Vagrantfile
+++ b/vagrant/multi_node/Vagrantfile
@@ -15,11 +15,6 @@ Vagrant.configure(2) do |config|
     vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
-  # On destroy, remove entries (if any) for the nodes in the host's ssh authorized keys
-  config.trigger.after :destroy do
-    run "ssh-keygen -R #{@machine.name}"
-  end
-
   nodes.each do |entry|
     config.vm.define entry[:hostname] do |node|
       node.vm.hostname = entry[:hostname]

--- a/vagrant/multi_node/ansible.cfg
+++ b/vagrant/multi_node/ansible.cfg
@@ -1,0 +1,3 @@
+[ssh_connection]
+
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/vagrant/multi_node/hosts/localmesos-cluster
+++ b/vagrant/multi_node/hosts/localmesos-cluster
@@ -1,25 +1,25 @@
 #inventory file for local multi-node cluster environment
 
 [machines]
-localmesos[02:04] env=test base_data_dir=/data shared_mount=/vagrant
+192.168.2.1[02:04] env=test base_data_dir=/data shared_mount=/vagrant
 
 [masters]
-localmesos[02:04]
+192.168.2.1[02:04]
 
 
 [zookeeper]
-localmesos02 zk_id=1
-localmesos03 zk_id=2
-localmesos04 zk_id=3
+192.168.2.102 zk_id=1
+192.168.2.103 zk_id=2
+192.168.2.104 zk_id=3
 
 [slaves]
-localmesos[03:04]
+192.168.2.1[03:04]
 
 [marathon_servers]
-localmesos[02:04]
+192.168.2.1[02:04]
 
 [docker_registry]
-localmesos02
+192.168.2.102
 
 [localmesos:children]
 masters

--- a/vagrant/multi_node/setup-multi-node.sh
+++ b/vagrant/multi_node/setup-multi-node.sh
@@ -8,15 +8,3 @@ vagrant reload
 
 echo "Running initial-cluster..."
 ansible-playbook -i hosts/localmesos-cluster --user=vagrant --ask-pass --extra-vars="mesos_cluster_name=localcluster-on-`hostname` mesos_master_network_interface=ansible_eth1 mesos_slave_network_interface=ansible_eth1" ../../ansible/initial-cluster.yml
-
-# restart Zookeeper
-ansible zookeeper -i hosts/localmesos-cluster --user=vagrant -s -m service -a "name=zookeeper state=restarted" --ask-pass
-
-# rstart mesos-master
-ansible masters -i hosts/localmesos-cluster --user=vagrant -s -m service -a "name=mesos-master state=restarted" --ask-pass
-
-# restart mesos-slave
-ansible slaves -i hosts/localmesos-cluster --user=vagrant -s -m service -a "name=mesos-slave state=restarted" --ask-pass
-
-#restart marathon
-ansible marathon_servers -i hosts/localmesos-cluster --user=vagrant -s -m service -a "name=marathon state=restarted" --ask-pass

--- a/vagrant/single_node/Vagrantfile
+++ b/vagrant/single_node/Vagrantfile
@@ -15,11 +15,6 @@ Vagrant.configure(2) do |config|
 
   config.vm.network :forwarded_port, guest: 22, host: 2223, id: "ssh"
 
-  # On destroy, remove entries (if any) for the nodes in the host's ssh authorized keys
-  config.trigger.after :destroy do
-    run "ssh-keygen -R #{@machine.name}"
-  end
-
   nodes.each do |entry|
     config.vm.define entry[:hostname] do |node|
       node.vm.hostname = entry[:hostname]

--- a/vagrant/single_node/Vagrantfile
+++ b/vagrant/single_node/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 nodes = [
-  { :hostname => 'localmesos01', :ip => '192.168.2.101', :mem => 4096, :cpus => 1 }
+  { :hostname => 'localmesos01', :ip => '192.168.2.101', :mem => 4096, :cpus => 2 }
 ]
 
 Vagrant.configure(2) do |config|

--- a/vagrant/single_node/ansible.cfg
+++ b/vagrant/single_node/ansible.cfg
@@ -1,0 +1,3 @@
+[ssh_connection]
+
+ssh_args=-o ControlMaster=auto -o ControlPersist=60s -o ControlPath=/tmp/ansible-ssh-%h-%p-%r -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null

--- a/vagrant/single_node/hosts/single
+++ b/vagrant/single_node/hosts/single
@@ -1,28 +1,28 @@
 # inventory file for 'single' environment
 
 [machines]
-localmesos01 env=test base_data_dir=/data shared_mount=/vagrant
+192.168.2.101 env=test base_data_dir=/data shared_mount=/vagrant
 
 [masters]
-localmesos01
+192.168.2.101
 
 [zookeeper]
-localmesos01 zk_id=1
+192.168.2.101 zk_id=1
 
 [slaves]
-localmesos01
+192.168.2.101
 
 [marathon_servers]
-localmesos01
+192.168.2.101
 
 [docker_registry]
-localmesos01
+192.168.2.101
 
 [single]
-localmesos01
+192.168.2.101
 
 [bamboo_servers]
-localmesos01
+192.168.2.101
 
 [haproxy]
-localmesos01
+192.168.2.101

--- a/vagrant/single_node/setup-single-node.sh
+++ b/vagrant/single_node/setup-single-node.sh
@@ -3,21 +3,9 @@ set -e
 set -u
 
 echo "Kernel reload()..."
-ansible-playbook -i hosts/single --user=vagrant --ask-pass ../../ansible/base.yml
+ansible-playbook -i hosts/single --user=vagrant --private-key='.vagrant/machines/localmesos01/virtualbox/private_key' ../../ansible/base.yml
 vagrant reload
 
 echo "Starting ansible-playbook to set up other services..."
 
-ansible-playbook -i hosts/single --user=vagrant --ask-pass --extra-vars="mesos_cluster_name=localcluster-on-`hostname` mesos_master_network_interface=ansible_eth1 mesos_slave_network_interface=ansible_eth1" ../../ansible/initial-cluster.yml
-
-# restart Zookeeper
-ansible zookeeper -i hosts/single --user=vagrant -s -m command -a "service zookeeper restart" --ask-pass
-
-# rstart mesos-master
-ansible masters -i hosts/single --user=vagrant -s -m command -a "service mesos-master restart" --ask-pass
-
-# restart mesos-slave
-ansible slaves -i hosts/single --user=vagrant -s -m command -a "service mesos-slave restart" --ask-pass
-
-#restart marathon
-ansible marathon_servers -i hosts/single --user=vagrant -s -m command -a "service marathon restart" --ask-pass
+ansible-playbook -i hosts/single --user=vagrant --private-key='.vagrant/machines/localmesos01/virtualbox/private_key' --extra-vars="mesos_cluster_name=localcluster-on-`hostname` mesos_master_network_interface=ansible_eth1 mesos_slave_network_interface=ansible_eth1" ../../ansible/initial-cluster.yml


### PR DESCRIPTION
1. Use the vagrant generated public key when connecting to the VM with
   ansible.
2. Update hosts file to use ip addresses instead of names. This obviates
   the need to use the hostupdater plugin which requires root permissions
   to update /etc/hosts
3. Use an ansible.cfg file to make the ssh connection for ansible
   disable host key checking and to not write the VM's host key to
   known_hosts file.
4. Remove the destroy trigger in the Vagrantfile used to purge the
   known_hosts file as this is no longer needed.

Signed-off-by: Arunabha Ghosh agh@moz.com
